### PR TITLE
Update 0.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,6 +60,9 @@ test:
 
 about:
   home: https://github.com/nucleic/enaml
+  description: |
+    Enaml is a programming language and framework for creating 
+    professional-quality user interfaces with minimal effort.
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ build:
   entry_points:
     - enaml-run = enaml.runner:main
     - enaml-compileall = enaml.compile_all:main
-  osx_is_app: true
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "enaml" %}
-{% set version = "0.13.0" %}
-{% set sha256 = "138224c353cae40af210d3d770377395855f19e7c1c5d449bfa1fd3d189c4801" %}
+{% set version = "0.16.0" %}
+{% set sha256 = "dee51e9099965de4dac3ba779a0852722ae7b1f1ae0f39f75dd15400171cd5a2" %}
 package:
   name: {{ name|lower }}
   version: {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<38]
+  skip: true  # [py<38 and (ppc64le or s390x)]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - enaml-run = enaml.runner:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Declarative DSL for building rich user interfaces in Python
-  doc_url: http://nucleic.github.io/enaml/docs/
+  doc_url: https://github.com/nucleic/enaml/tree/main/docs
   dev_url: https://github.com/nucleic/enaml
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,8 +72,8 @@ about:
   license_file: LICENSE
   summary: Declarative DSL for building rich user interfaces in Python
   doc_url: https://github.com/nucleic/enaml/tree/main/docs
-  dev_url: https://github.com/nucleic/enaml/blob/main/releasenotes.rst
-
+  dev_url: https://github.com/nucleic/enaml
+  
 extra:
   recipe-maintainers:
     - blink1073

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,12 +12,12 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38 or ppc64le]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - enaml-run = enaml.runner:main
     - enaml-compileall = enaml.compile_all:main
-  osx_is_app: true 
+  osx_is_app: true
 
 requirements:
   build:
@@ -76,3 +76,5 @@ extra:
     - licode
     - MatthieuDartiailh
     - tacaswell
+    - marcelotrevisani
+    - gabrielcnr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,28 +23,31 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - python >=3.6
+    - python
     - setuptools
+    - wheel
     - pip
-    - atom >=0.6.0
-    - kiwisolver >=1.2.0
-    - ply >=3.4
-    - qtpy >=1.3
-    - cppy >=1.1.0
-    - bytecode >=0.11.0
+    - atom
+    - kiwisolver
+    - ply
+    - qtpy
+    - cppy
+    - bytecode
   run:
-    - python >=3.6
+    - python
     - python.app  # [osx]
-    - atom >=0.6.0
-    - pyqt
-    - qtpy >=1.3
+    - atom >=0.9.0
     - kiwisolver >=1.2.0
-    - ply >=3.4
-    - bytecode >=0.11.0
+    - ply
+    - bytecode >=0.13.0
+    - pegen >=0.1.0
 
 test:
+  requires:
+    - pip
   commands:
     - enaml-run --help
+    - pip check
   imports:
     - enaml
     - enaml.callableref

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python
+    - pip
     - setuptools
     - wheel
     - setuptools_scm

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ build:
   entry_points:
     - enaml-run = enaml.runner:main
     - enaml-compileall = enaml.compile_all:main
+  osx_is_app: true 
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,9 +71,9 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Declarative DSL for building rich user interfaces in Python
-  doc_url: https://github.com/nucleic/enaml/tree/main/docs
+  doc_url: https://enaml.readthedocs.io/
   dev_url: https://github.com/nucleic/enaml
-  
+
 extra:
   recipe-maintainers:
     - blink1073

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,7 @@ about:
   license_file: LICENSE
   summary: Declarative DSL for building rich user interfaces in Python
   doc_url: https://github.com/nucleic/enaml/tree/main/docs
-  dev_url: https://github.com/nucleic/enaml
+  dev_url: https://github.com/nucleic/enaml/blob/main/releasenotes.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [ppc64le]
+  skip: True  # [py<38 or ppc64le]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - enaml-run = enaml.runner:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,19 +26,15 @@ requirements:
     - python
     - setuptools
     - wheel
-    - pip
-    - atom
-    - kiwisolver
-    - ply
-    - qtpy
-    - cppy
-    - bytecode
+    - setuptools_scm
+    - toml
+    - cppy 1.2.1
+    - bytecode 0.14.0
   run:
     - python
-    - python.app  # [osx]
+    - ply
     - atom >=0.9.0
     - kiwisolver >=1.2.0
-    - ply
     - bytecode >=0.13.0
     - pegen >=0.1.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<38 and (ppc64le or s390x)]
+  skip: true  # [py<38 or ppc64le or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - enaml-run = enaml.runner:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,9 @@ requirements:
     - bytecode 0.14.0
   run:
     - python
+    - python.app  # [osx]
+    - pyqt
+    - qtpy >=2.1.0
     - ply
     - atom >=0.9.0
     - kiwisolver >=1.2.0


### PR DESCRIPTION
[Upstream](https://github.com/nucleic/enaml)
[Changelog](https://github.com/nucleic/enaml/releases)

### Actions
- Update version to 0.16.0 and update sha256
- Add skip for py<38
- skip ppc64le and s390x (enaml not built on both)
- Update dependencies
- Linter fixes (doc_url, description, dev_url)
- Recipe cleanup